### PR TITLE
Fixed PHP error when product price is empty.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -63,7 +63,7 @@ class WooCommerce {
     else {
       $category = static::getProductCategoriesParentsList($product_id);
     }
-error_log(print_r($product->get_price(), TRUE));
+
     $details = [
       'id' => $product_id,
       'sku' => $product->get_sku() ?: $product_id,


### PR DESCRIPTION
Related to task https://app.asana.com/0/inbox/383242129844222/644382535054036/644414092375072

Prevent error when product price is empty/undefined.