### PR TITLE
Fixed removing commas from product price throwed js error.

### DIFF
--- a/assets/scripts/datalayer/common.js
+++ b/assets/scripts/datalayer/common.js
@@ -26,12 +26,10 @@ document.shopAnalytics = {
       var product = {
         name: product_data.name,
         id: String(product_data.sku),
+        price: product_data.price,
         category: product_data.category,
       };
-      if (product_data.price) {
-        // If product price is less than 1.000 it gets casted as a number, otherwise it's a string.
-        product.price = (typeof product_data.price === 'string') ? product_data.price.replace(/,/g, '') : product_data.price;
-      }
+
       if (product_data.brand) {
         product.brand = product_data.brand;
       }

--- a/dist/scripts/datalayer/common.js
+++ b/dist/scripts/datalayer/common.js
@@ -7,9 +7,9 @@ window.dataLayer = window.dataLayer || [], document.shopAnalytics = {
             var t = jQuery(this), a = t.data(), o = {
                 name: a.name,
                 id: String(a.sku),
+                price: a.price,
                 category: a.category
             };
-            a.price && (o.price = "string" == typeof a.price ? a.price.replace(/,/g, "") : a.price), 
             a.brand && (o.brand = a.brand), a.variant && (o.variant = a.variant), a.quantity && (o.quantity = parseInt(a.quantity)), 
             a.position && (o.position = a.position), a.list && (o.list = a.list), e.push(o);
         }), e;

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -69,7 +69,7 @@ class WooCommerce {
       'sku' => $product->get_sku() ?: $product_id,
       'name' => str_replace(["'", '"'], '', wp_strip_all_tags($product->get_name(), TRUE)),
       'type' => $product->get_type(),
-      'price' => number_format($product->get_price() ?: 0, 2),
+      'price' => number_format($product->get_price() ?: 0, 2, '.', ''),
       'category' => $category,
       'brand' => static::getProductBrand($product_id),
       'gtin' => ($gtin = get_post_meta($product_id, '_custom_gtin', TRUE)) ? $gtin : '' ,


### PR DESCRIPTION
Related to task
https://app.asana.com/0/inbox/383242129844222/650474538174186/650629295010991

On frontend, product price gets casted as number if it is less than 1.000. This triggers a JS error when trying to remove ',' as thousands separator.