### PR TITLE
Fixed PHP notice thrown when a product attribute is not a term from a valid taxonomy.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -337,7 +337,8 @@ class WooCommerce {
       foreach ($attributes as $attribute_name => $options) {
         $attribute = isset($_REQUEST['attribute_' . sanitize_title($attribute_name)]) ? wc_clean(stripslashes(urldecode($_REQUEST['attribute_' . sanitize_title($attribute_name)]))) : '';
         if ($attribute) {
-          $selected_attributes[] = get_term_by('slug', $attribute, $attribute_name)->name;
+          $attribute_term_data = get_term_by('slug', $attribute, $attribute_name);
+          $selected_attributes[] = $attribute_term_data ? $attribute_term_data->name : $attribute;
         }
       }
       if ($selected_attributes) {


### PR DESCRIPTION
Related to task:
- [Fix PHP notice: single product page (seminare)](https://app.asana.com/0/383242129844224/971704108587932)
