### PR TITLE
Fixed non-exsiting custom meta field GTIN was tracked.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shop-analytics",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Integrates Google Tag Manager and Google Analytics into WooCommerce.",
   "main": "gulpfile.js",
   "author": "netzstrategen <hallo@netzstrategen.com>",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Analytics
-  Version: 1.5.6
+  Version: 1.5.7
   Text Domain: shop-analytics
   Description: Integrates Google Tag Manager and Google Analytics into WooCommerce.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -77,7 +77,6 @@ class WooCommerce {
       'price' => number_format($product->get_price() ?: 0, 2, '.', ''),
       'category' => $category,
       'brand' => static::getProductBrand($product_id),
-      'gtin' => ($gtin = get_post_meta($product_id, '_custom_gtin', TRUE)) ? $gtin : '' ,
       'availability' => $product->is_in_stock() ? __('In stock', Plugin::L10N) : __('Out of stock', Plugin::L10N),
       'stock' => (int) $product->get_stock_quantity(),
     ];


### PR DESCRIPTION
### Ticket
- [shop-analytics: Wrong meta data is output for tracking](https://app.asana.com/0/354170587449545/1138078048851338/f)

### Description
-
