### PR TITLE
Added tracking of product GTIN from plugin shop-standards.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,13 +27,6 @@ class Plugin {
   const L10N = self::PREFIX;
 
   /**
-   * Product GTIN custom meta field name.
-   *
-   * @var string
-   */
-  const GTIN_CUSTOM_FIELD_NAME = '_shop-standards_gtin';
-
-  /**
    * @var string
    */
   private static $baseUrl;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,6 +27,13 @@ class Plugin {
   const L10N = self::PREFIX;
 
   /**
+   * Product GTIN custom meta field name.
+   *
+   * @var string
+   */
+  const GTIN_CUSTOM_FIELD_NAME = '_shop-standards_gtin';
+
+  /**
    * @var string
    */
   private static $baseUrl;

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -81,6 +81,11 @@ class WooCommerce {
       'stock' => (int) $product->get_stock_quantity(),
     ];
 
+    // Adds product GTIN from plugin shop-standards.
+    if ($gtin = get_post_meta($product_id, '_shop-standards_gtin', TRUE)) {
+      $details['gtin'] = $gtin;
+    }
+
     if ($product_tags = static::getProductTagsList($product_id)) {
       $details['tag'] = $product_tags;
     }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -81,8 +81,8 @@ class WooCommerce {
       'stock' => (int) $product->get_stock_quantity(),
     ];
 
-    // Adds product GTIN from plugin shop-standards.
-    if ($gtin = get_post_meta($product_id, '_shop-standards_gtin', TRUE)) {
+    // Adds product GTIN retrieved from a custom meta field.
+    if ($gtin = get_post_meta($product_id, Plugin::GTIN_CUSTOM_FIELD_NAME, TRUE)) {
       $details['gtin'] = $gtin;
     }
 

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -82,7 +82,7 @@ class WooCommerce {
     ];
 
     // Adds product GTIN retrieved from a custom meta field.
-    if ($gtin = get_post_meta($product_id, Plugin::GTIN_CUSTOM_FIELD_NAME, TRUE)) {
+    if ($gtin = get_post_meta($product_id, apply_filters(Plugin::PREFIX . '_gtin_custom_field_name', '_shop-standards_gtin'), TRUE)) {
       $details['gtin'] = $gtin;
     }
 


### PR DESCRIPTION
### Ticket
- [shop-analytics: Wrong meta data is output for tracking](https://app.asana.com/0/354170587449545/1138078048851338/f)

### Description
- Migrating the tracking of product GTIN to plugin shop-standards would need an over-complicated implementation, as shop-analytics injects hidden `div` tags to keep track of data details for each product instance (single, impressions in listings, etc).
- Checking the existence of custom field `_shop-standards_gtin` to get the product GTIN value is far more simple.
