### PR TITLE
Fixed PHP error when retrieving order coupons in older woocommerce versions.

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -432,7 +432,7 @@ class WooCommerce {
       'payment-method' => $order_data['payment_method_title'],
     ];
 
-    if ($coupons = $order->get_coupon_codes()) {
+    if ($coupons = static::getOrderCoupons($order)) {
       $order_details['coupon'] = implode(' | ', $coupons);
     }
 
@@ -446,6 +446,26 @@ class WooCommerce {
     $html .= '</div>';
 
     return $html;
+  }
+
+  /**
+   * Retrieves the discount coupons of a given order.
+   *
+   * @param WC_Order $order
+   *   Order to retrieve coupons from.
+   *
+   * @return array
+   *   Discount coupons.
+   */
+  public static function getOrderCoupons($order) {
+    if (version_compare(WC_VERSION, '3.7.0', '<')) {
+      $coupons = $order->get_used_coupons();
+    }
+    else {
+      $coupons = $order->get_coupon_codes();
+    }
+
+    return $coupons;
   }
 
   /**


### PR DESCRIPTION
PHP fatal error is thrown when order discount coupons are retrieved if WooCommerce version is older than 3.7.0. E.g. GACO.

[Reported by Marc Binz on Slack](https://netzstrategen.slack.com/archives/CLGJ41RPW/p1572962853002500?thread_ts=1572962391.002200&cid=CLGJ41RPW).
```
Fatal error: Uncaught Error: Call to undefined method WC_Order::get_coupon_codes() in /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/shop-analytics/src/WooCommerce.php:435 Stack trace: #0 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/shop-analytics/src/WooCommerce.php(411): Netzstrategen\ShopAnalytics\WooCommerce::getOrderDetailsHtmlDataAttr(198506) #1 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-includes/class-wp-hook.php(286): Netzstrategen\ShopAnalytics\WooCommerce::addOrderDetailsHtmlDataAttr(198506) #2 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array) #3 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-includes/plugin.php(465): WP_Hook->do_action(Array) #4 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/woocommerce/templates/checkout/thankyou.php(78): do_action('woocommerce_tha...', 198506) #5 /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/woocommerce/includes/wc-core-functions.php( in /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/shop-analytics/src/WooCommerce.php on line 435
```
