### PR TITLE
Fixed plugin settings page was broken if woocommerce plugin is inactive.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shop-analytics",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Integrates Google Tag Manager and Google Analytics into WooCommerce.",
   "main": "gulpfile.js",
   "author": "netzstrategen <hallo@netzstrategen.com>",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Analytics
-  Version: 1.9.2
+  Version: 1.9.3
   Text Domain: shop-analytics
   Description: Integrates Google Tag Manager and Google Analytics into WooCommerce.
   Author: netzstrategen

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -4,9 +4,11 @@ namespace Netzstrategen\ShopAnalytics;
 
 global $wp_roles;
 
-$product_attributes = wc_get_attribute_taxonomies();
-$brand_attribute = get_option('shop_analytics_brand_attribute', 'product_brand');
-$category_attribute = get_option('shop_analytics_category_attribute', 'product_cat');
+$product_attributes = function_exists('wc_get_attribute_taxonomies') ? wc_get_attribute_taxonomies() : '';
+if ($product_attributes) {
+  $brand_attribute = get_option('shop_analytics_brand_attribute', 'product_brand');
+  $category_attribute = get_option('shop_analytics_category_attribute', 'product_cat');
+}
 ?>
 
 <div class="wrap">


### PR DESCRIPTION
### Description
- A PHP fatal error was thrown on shop-analytics backend settings page if woocommerce is not installed/active.

```
Fatal error: Uncaught Error: Call to undefined function Netzstrategen\ShopAnalytics\wc_get_attribute_taxonomies() in
/var/www/vhosts/mpm-processmining.com/htdocs/wp-content/plugins/shop-analytics/templates/settings.php:7
Stack trace: #0
/var/www/vhosts/mpm-processmining.com/htdocs/wp-content/plugins/shop-analytics/src/Plugin.php(396):
include() #1
/var/www/vhosts/mpm-processmining.com/htdocs/wp-content/plugins/shop-analytics/src/Admin.php(50):
Netzstrategen\ShopAnalytics\Plugin::renderTemplate(Array) #2
/var/www/vhosts/mpm-processmining.com/htdocs/wp-includes/class-wp-hook.php(286):
Netzstrategen\ShopAnalytics\Admin::renderSettings('') #3
/var/www/vhosts/mpm-processmining.com/htdocs/wp-includes/class-wp-hook.php(310):
WP_Hook->apply_filters('', Array) #4
/var/www/vhosts/mpm-processmining.com/htdocs/wp-includes/plugin.php(453):
WP_Hook->do_action(Array) #5
/var/www/vhosts/mpm-processmining.com/htdocs/wp-admin/admin.php(224):
do_action('toplevel_page_s...') #6 {main}
thrown in /var/www/vhosts/mpm-processmining.com/htdocs/wp-content/plugins/shop-analytics/templates/settings.php on line 7
```
