### PR TITLE
Fixed fatal error when editing product with Divi theme.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shop-analytics",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Integrates Google Tag Manager and Google Analytics into WooCommerce.",
   "main": "gulpfile.js",
   "author": "netzstrategen <hallo@netzstrategen.com>",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Shop Analytics
-  Version: 1.12.0
+  Version: 1.12.1
   Text Domain: shop-analytics
   Description: Integrates Google Tag Manager and Google Analytics into WooCommerce.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -56,6 +56,9 @@ class WooCommerce {
   public static function getProductDetails($product_id = 0, $primary_category = TRUE) {
     $product_id = $product_id ?: get_the_ID();
     $product = wc_get_product($product_id);
+    if (!$product || is_wp_error($product)) {
+      return [];
+    }
     $parent_id = $product->get_parent_id();
 
     if ($primary_category) {


### PR DESCRIPTION
### Ticket
- [WP shop-analytics: fatal error when using page builder "divi"](https://app.asana.com/0/1201936618042188/1202797572116957)

### Description
- The Divi theme seems to pass a product ID into the WooCommerce product template, without checking whether that product actually exists.

Related issues
- https://wordpress.org/support/topic/incompatibility-with-the-divi-theme-3/
- https://wordpress.org/support/topic/php-fatal-error-296/

Proposed solution
1. Double-check whether the passed product ID could be loaded before operating on it.
