### PR TITLE
feat: update GA4 ecommerce events. (#61)

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -359,7 +359,7 @@ class WooCommerce {
     $product_details['item_key'] = $cart_item_key;
     if ('variation' === $product->get_type()) {
       $attributes = wc_get_product($product)->get_variation_attributes();
-      $selected_attributes = array_values($attributes);
+      $selected_attributes = array_map('trim', array_values($attributes));
       if ($selected_attributes) {
         $product_details['variant'] = strtolower(implode('-', $selected_attributes));
       }
@@ -430,6 +430,7 @@ class WooCommerce {
         }
       }
       if ($selected_attributes) {
+        $selected_attributes = array_map('trim', $selected_attributes);
         $product_details['variant'] = strtolower(implode('-', $selected_attributes));
       }
     }

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -358,7 +358,11 @@ class WooCommerce {
 
     $product_details['item_key'] = $cart_item_key;
     if ('variation' === $product->get_type()) {
-      $product_details['variant'] = wc_get_formatted_variation(wc_get_product($product)->get_variation_attributes(), TRUE);
+      $attributes = wc_get_product($product)->get_variation_attributes();
+      $selected_attributes = array_values($attributes);
+      if ($selected_attributes) {
+        $product_details['variant'] = strtolower(implode('-', $selected_attributes));
+      }
     }
 
     return str_replace('<a ', '<span class="shop-analytics-product-info" ' . Plugin::buildAttributesDataTags($product_details) . ' data-quantity="' . $cart_item['quantity'] . '"></span><a ', $link);
@@ -395,6 +399,21 @@ class WooCommerce {
     $product_id = $product->get_id();
     $product_details = static::getProductDetails($product_id);
 
+    // For variations, override the name with the parent product name
+    if ($product->get_type() === 'variation') {
+      $parent_id = $product->get_parent_id();
+      if ($parent_id) {
+        $parent_product = wc_get_product($parent_id);
+        if ($parent_product) {
+          // Check for custom product name on parent, otherwise use parent's name
+          if (!$parent_name = get_post_meta($parent_id, Plugin::PREFIX . '_custom_product_name', TRUE)) {
+            $parent_name = str_replace(["'", '"'], '', wp_strip_all_tags($parent_product->get_name(), TRUE));
+          }
+          $product_details['name'] = $parent_name;
+        }
+      }
+    }
+
     if (($product->get_type() === 'variable' && $is_detail_view) || ($product->get_type() === 'variation' && !isset($product_details['variant']))) {
       $attributes = $product->get_variation_attributes();
       $selected_attributes = [];
@@ -411,7 +430,7 @@ class WooCommerce {
         }
       }
       if ($selected_attributes) {
-        $product_details['variant'] = implode(', ', $selected_attributes);
+        $product_details['variant'] = strtolower(implode('-', $selected_attributes));
       }
     }
 


### PR DESCRIPTION
This pull request refines how product variant and parent product names are handled for WooCommerce products, particularly for product variations. The changes improve the consistency and accuracy of product detail data attributes, ensuring better analytics and display.

**Variant and product name handling improvements:**

* When generating product details for cart item removal links, the variant attribute is now a lowercase, hyphen-separated string of selected attribute values, instead of using WooCommerce's formatted variation string.
* In product detail data attributes, if the product is a variation, the name is now overridden with the parent product's name (or a custom name if set), ensuring consistent naming for analytics and display.
* The variant attribute in product detail data attributes is now set as a lowercase, hyphen-separated string of selected attribute values, improving consistency with the cart item removal logic.